### PR TITLE
add correct prefix and marker when echoing XMP metadata into CVT jpeg

### DIFF
--- a/src/CVT.cc
+++ b/src/CVT.cc
@@ -362,8 +362,21 @@ void CVT::send( Session* session ){
 
   // Add XMP metadata if this exists
   if( (*session->image)->getMetadata("xmp").size() > 0 ){
+  	// the XMP data in a JPEG stream needs to be prefixed with a zero-terminated ID string
+	// ref http://www.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/cs6/XMPSpecificationPart3.pdf (pp13-14)
+	// so have to copy it into a larger buffer
+    char xmpstr[65536];	// per spec, XMP max size is 65502; namespace prefix/id is 29 bytes
+
     if( session->loglevel >= 4 ) *(session->logfile) << "CVT :: Adding XMP metadata" << endl;
-    session->jpeg->addMetadata( (*session->image)->getMetadata("xmp") );
+    
+	// '0' should be 0, but snprintf is too smart...
+	snprintf( xmpstr, 65536, "http://ns.adobe.com/xap/1.0/%c%s", '0', (*session->image)->getMetadata("xmp").c_str() );
+	xmpstr[28] = 0; // overwrite '0'
+
+	// can't use regular addMetadata, because of the zero term after the namespace id; and the APP1 marker
+	//	session->jpeg->addMetadata( xmpstr );
+
+	session->jpeg->addGenericMetadata(JPEG_APP0+1, xmpstr, 29 + (*session->image)->getMetadata("xmp").size());
   }
 
   len = session->jpeg->getHeaderSize();

--- a/src/JPEGCompressor.cc
+++ b/src/JPEGCompressor.cc
@@ -451,3 +451,12 @@ int JPEGCompressor::Compress( RawTile& rawtile ) throw (string)
 void JPEGCompressor::addMetadata( const string& metadata ){
   jpeg_write_marker( &cinfo, JPEG_APP0, (const JOCTET*) metadata.c_str(), metadata.size() );
 }
+
+
+// for XMP metadata, the XMP packet is prefixed with a null-terminated ID string -
+// hence the size() call in the regular JPEGCompressor::addMetadata function defined
+// above will return an incorrect value.
+//
+void JPEGCompressor::addGenericMetadata(int marker, char * metadata, unsigned int datalen ) {
+  jpeg_write_marker( &cinfo, marker, (const JOCTET*) metadata, datalen);
+}

--- a/src/JPEGCompressor.h
+++ b/src/JPEGCompressor.h
@@ -136,6 +136,12 @@ class JPEGCompressor{
   /** @param m metadata */
   void addMetadata( const std::string& m );
 
+  /// Add metadata to the JPEG header, with explicit marker and size
+  /** @param marker JPEG marker
+      @param m metadata
+      @param datalen length of metadata
+   */
+  void addGenericMetadata(int marker, char * metadata, unsigned int datalen );
 
   /// Return the JPEG header size
   unsigned int getHeaderSize() { return header_size; }


### PR DESCRIPTION
Currently, XMP metadata from a source TIFF or PTIF file is copied into a 'CVT' jpeg, but the data will not be exposed by standard readers because it lacks the correct marker and ID.